### PR TITLE
upgrade, fix issues when running with v0.12.0

### DIFF
--- a/terraform_demo/autoscaling_groups/webapp-asg.tf
+++ b/terraform_demo/autoscaling_groups/webapp-asg.tf
@@ -10,14 +10,14 @@
 # License for the specific language governing permissions and limitations under the License.
 resource "aws_autoscaling_group" "webapp_asg" {
   lifecycle { create_before_destroy = true }
-  vpc_zone_identifier = ["${var.public_subnet_id}"]
+  vpc_zone_identifier = [var.public_subnet_id]
   name = "demo_webapp_asg-${var.webapp_lc_name}"
-  max_size = "${var.asg_max}"
-  min_size = "${var.asg_min}"
-  wait_for_elb_capacity = false
+  max_size = var.asg_max
+  min_size = var.asg_min
+  wait_for_elb_capacity = 0
   force_delete = true
-  launch_configuration = "${var.webapp_lc_id}"
-  load_balancers = ["${var.webapp_elb_name}"]
+  launch_configuration = var.webapp_lc_id
+  load_balancers = [var.webapp_elb_name]
   tag {
     key = "Name"
     value = "terraform_asg"
@@ -33,7 +33,7 @@ resource "aws_autoscaling_policy" "scale_up" {
   scaling_adjustment = 2
   adjustment_type = "ChangeInCapacity"
   cooldown = 300
-  autoscaling_group_name = "${aws_autoscaling_group.webapp_asg.name}"
+  autoscaling_group_name = aws_autoscaling_group.webapp_asg.name
 }
 resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
   alarm_name = "terraform-demo-high-asg-cpu"
@@ -45,8 +45,8 @@ resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
   statistic = "Average"
   threshold = "80"
   insufficient_data_actions = []
-  dimensions {
-      AutoScalingGroupName = "${aws_autoscaling_group.webapp_asg.name}"
+  dimensions = {
+      AutoScalingGroupName = aws_autoscaling_group.webapp_asg.name
   }
   alarm_description = "EC2 CPU Utilization"
   alarm_actions = ["${aws_autoscaling_policy.scale_up.arn}"]
@@ -60,7 +60,7 @@ resource "aws_autoscaling_policy" "scale_down" {
   scaling_adjustment = -1
   adjustment_type = "ChangeInCapacity"
   cooldown = 600
-  autoscaling_group_name = "${aws_autoscaling_group.webapp_asg.name}"
+  autoscaling_group_name = aws_autoscaling_group.webapp_asg.name
 }
 
 resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
@@ -73,12 +73,12 @@ resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
   statistic = "Average"
   threshold = "30"
   insufficient_data_actions = []
-  dimensions {
-      AutoScalingGroupName = "${aws_autoscaling_group.webapp_asg.name}"
+  dimensions = {
+      AutoScalingGroupName = aws_autoscaling_group.webapp_asg.name
   }
   alarm_description = "EC2 CPU Utilization"
   alarm_actions = ["${aws_autoscaling_policy.scale_down.arn}"]
 }
 output "asg_id" {
-  value = "${aws_autoscaling_group.webapp_asg.id}"
+  value = aws_autoscaling_group.webapp_asg.id
 }

--- a/terraform_demo/instances/bastion.tf
+++ b/terraform_demo/instances/bastion.tf
@@ -9,18 +9,18 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 resource "aws_instance" "bastion" {
-  ami = "${lookup(var.amis, var.region)}"
-  instance_type = "${var.instance_type}"
+  ami = lookup(var.amis, var.region)
+  instance_type = var.instance_type
   tags = {
     Name = "terraform_bastion"
   }
-  subnet_id = "${var.public_subnet_id}"
+  subnet_id = var.public_subnet_id
   associate_public_ip_address = true
-  vpc_security_group_ids = ["${var.bastion_ssh_sg_id}"]
-  key_name = "${var.key_name}"
+  vpc_security_group_ids = [var.bastion_ssh_sg_id]
+  key_name = var.key_name
 }
 
 resource "aws_eip" "bastion" {
-  instance = "${aws_instance.bastion.id}"
+  instance = aws_instance.bastion.id
   vpc = true
 }

--- a/terraform_demo/instances/private_subnet_instance.tf
+++ b/terraform_demo/instances/private_subnet_instance.tf
@@ -9,15 +9,15 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 resource "aws_instance" "private_subnet_instance" {
-  ami = "${lookup(var.amis, var.region)}"
-  instance_type = "${var.instance_type}"
+  ami = lookup(var.amis, var.region)
+  instance_type = var.instance_type
   tags = {
     Name = "terraform_demo_private_subnet"
   }
-  subnet_id = "${var.private_subnet_id}"
+  subnet_id = var.private_subnet_id
   vpc_security_group_ids = [
-    "${var.ssh_from_bastion_sg_id}",
-    "${var.web_access_from_nat_sg_id}"
+    var.ssh_from_bastion_sg_id,
+    var.web_access_from_nat_sg_id
     ]
-  key_name = "${var.key_name}"
+  key_name = var.key_name
 }

--- a/terraform_demo/launch_configurations/webapp-lc.tf
+++ b/terraform_demo/launch_configurations/webapp-lc.tf
@@ -10,20 +10,20 @@
 # License for the specific language governing permissions and limitations under the License.
 resource "aws_launch_configuration" "webapp_lc" {
   lifecycle { create_before_destroy = true }
-  image_id = "${lookup(var.amis, var.region)}"
-  instance_type = "${var.instance_type}"
+  image_id = lookup(var.amis, var.region)
+  instance_type = var.instance_type
   security_groups = [
-    "${var.webapp_http_inbound_sg_id}",
-    "${var.webapp_ssh_inbound_sg_id}",
-    "${var.webapp_outbound_sg_id}"
+    var.webapp_http_inbound_sg_id,
+    var.webapp_ssh_inbound_sg_id,
+    var.webapp_outbound_sg_id
   ]
-  user_data = "${file("./launch_configurations/userdata.sh")}"
-  key_name = "${var.key_name}"
+  user_data = file("./launch_configurations/userdata.sh")
+  key_name = var.key_name
   associate_public_ip_address = true
 }
 output "webapp_lc_id" {
-  value = "${aws_launch_configuration.webapp_lc.id}"
+  value = aws_launch_configuration.webapp_lc.id
 }
 output "webapp_lc_name" {
-  value = "${aws_launch_configuration.webapp_lc.name}"
+  value = aws_launch_configuration.webapp_lc.name
 }

--- a/terraform_demo/load_balancers/webapp-elb.tf
+++ b/terraform_demo/load_balancers/webapp-elb.tf
@@ -10,7 +10,7 @@
 # License for the specific language governing permissions and limitations under the License.
 resource "aws_elb" "webapp_elb" {
   name = "demo-webapp-elb"
-  subnets = ["${var.public_subnet_id}"]
+  subnets = [var.public_subnet_id]
   listener {
     instance_port = 80
     instance_protocol = "http"
@@ -24,11 +24,11 @@ resource "aws_elb" "webapp_elb" {
     target = "HTTP:80/"
     interval = 10
   }
-  security_groups = ["${var.webapp_http_inbound_sg_id}"]
-  tags {
+  security_groups = [var.webapp_http_inbound_sg_id]
+  tags = {
       Name = "terraform_elb"
   }
 }
 output "webapp_elb_name" {
-  value = "${aws_elb.webapp_elb.name}"
+  value = aws_elb.webapp_elb.name
 }

--- a/terraform_demo/main.tf
+++ b/terraform_demo/main.tf
@@ -9,19 +9,19 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 provider "aws" {
-  region = "${var.region}"
+  region = var.region
 }
 module "site" {
   source = "./site"
-  key_name = "${var.key_name}"
-  ip_range = "${var.ip_range}"
+  key_name = var.key_name
+  ip_range = var.ip_range
 }
 module "launch_configurations" {
   source = "./launch_configurations"
   webapp_http_inbound_sg_id = "${module.site.webapp_http_inbound_sg_id}"
   webapp_ssh_inbound_sg_id = "${module.site.webapp_ssh_inbound_sg_id}"
   webapp_outbound_sg_id = "${module.site.webapp_outbound_sg_id}"
-  key_name = "${var.key_name}"
+  key_name = var.key_name
 }
 module "load_balancers" {
   source = "./load_balancers"
@@ -42,5 +42,5 @@ module "instances" {
   private_subnet_id = "${module.site.private_subnet_id}"
   ssh_from_bastion_sg_id = "${module.site.ssh_from_bastion_sg_id}"
   web_access_from_nat_sg_id = "${module.site.web_access_from_nat_sg_id}"
-  key_name = "${var.key_name}"
+  key_name = var.key_name
 }

--- a/terraform_demo/site/bastion-sg.tf
+++ b/terraform_demo/site/bastion-sg.tf
@@ -15,7 +15,7 @@ resource "aws_security_group" "bastion_ssh_sg" {
     from_port = 22
     to_port = 22
     protocol = "tcp"
-    cidr_blocks = ["${var.ip_range}"]
+    cidr_blocks = [var.ip_range]
   }
   egress {
     from_port = 0
@@ -23,13 +23,13 @@ resource "aws_security_group" "bastion_ssh_sg" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform_bastion_ssh"
   }
 }
 output "bastion_ssh_sg_id" {
-  value = "${aws_security_group.bastion_ssh_sg.id}"
+  value = aws_security_group.bastion_ssh_sg.id
 }
 
 resource "aws_security_group" "ssh_from_bastion_sg" {
@@ -40,15 +40,15 @@ resource "aws_security_group" "ssh_from_bastion_sg" {
     to_port = 22
     protocol = "tcp"
     security_groups = [
-      "${aws_security_group.bastion_ssh_sg.id}",
-      "${aws_security_group.nat.id}"
+      aws_security_group.bastion_ssh_sg.id,
+      aws_security_group.nat.id
     ]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform_ssh_from_bastion"
   }
 }
 output "ssh_from_bastion_sg_id" {
-  value = "${aws_security_group.ssh_from_bastion_sg.id}"
+  value = aws_security_group.ssh_from_bastion_sg.id
 }

--- a/terraform_demo/site/nat-sg.tf
+++ b/terraform_demo/site/nat-sg.tf
@@ -15,19 +15,19 @@ resource "aws_security_group" "nat" {
     from_port = 80
     to_port = 80
     protocol = "tcp"
-    cidr_blocks = ["${var.private_subnet_cidr}"]
+    cidr_blocks = [var.private_subnet_cidr]
   }
   ingress {
     from_port = 443
     to_port = 443
     protocol = "tcp"
-    cidr_blocks = ["${var.private_subnet_cidr}"]
+    cidr_blocks = [var.private_subnet_cidr]
   }
   ingress {
     from_port = -1
     to_port = -1
     protocol = "icmp"
-    cidr_blocks = ["${var.private_subnet_cidr}"]
+    cidr_blocks = [var.private_subnet_cidr]
   }
   egress {
     from_port = 0
@@ -35,13 +35,13 @@ resource "aws_security_group" "nat" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform"
   }
 }
 output "nat_sg_id" {
-  value = "${aws_security_group.nat.id}"
+  value = aws_security_group.nat.id
 }
 
 resource "aws_security_group" "web_access_from_nat_sg" {
@@ -71,11 +71,11 @@ resource "aws_security_group" "web_access_from_nat_sg" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform"
   }
 }
 output "web_access_from_nat_sg_id" {
-  value = "${aws_security_group.web_access_from_nat_sg.id}"
+  value = aws_security_group.web_access_from_nat_sg.id
 }

--- a/terraform_demo/site/pub_priv_vpc.tf
+++ b/terraform_demo/site/pub_priv_vpc.tf
@@ -9,21 +9,21 @@
 # BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations under the License.
 resource "aws_vpc" "default" {
-  cidr_block = "${var.vpc_cidr}"
+  cidr_block = var.vpc_cidr
   enable_dns_hostnames = true
-  tags {
+  tags = {
       Name = "terraform_vpc"
   }
 }
 
 resource "aws_internet_gateway" "default" {
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform_igw"
   }
 }
 output "vpc_id" {
-  value = "${aws_vpc.default.id}"
+  value = aws_vpc.default.id
 }
 
 #
@@ -31,20 +31,20 @@ output "vpc_id" {
 #
 resource "aws_instance" "nat" {
   ami = "ami-75ae8245" # this is a special ami preconfigured to do NAT
-  availability_zone = "${element(var.availability_zones, 0)}"
+  availability_zone = element(var.availability_zones, 0)
   instance_type = "t2.small"
-  key_name = "${var.key_name}"
+  key_name = var.key_name
   security_groups = ["${aws_security_group.nat.id}"]
-  subnet_id = "${aws_subnet.demo_public.id}"
+  subnet_id = aws_subnet.demo_public.id
   associate_public_ip_address = true
   source_dest_check = false
-  tags {
+  tags = {
       Name = "terraform_nat_instance"
   }
 }
 
 resource "aws_eip" "nat" {
-  instance = "${aws_instance.nat.id}"
+  instance = aws_instance.nat.id
   vpc = true
 }
 
@@ -52,60 +52,60 @@ resource "aws_eip" "nat" {
 # Public Subnet
 #
 resource "aws_subnet" "demo_public" {
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${var.public_subnet_cidr}"
-  availability_zone = "${element(var.availability_zones, 0)}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  cidr_block = var.public_subnet_cidr
+  availability_zone = element(var.availability_zones, 0)
+  tags = {
       Name = "terraform_public_subnet"
   }
 }
 output "public_subnet_id" {
-  value = "${aws_subnet.demo_public.id}"
+  value = aws_subnet.demo_public.id
 }
 
 resource "aws_route_table" "demo_public" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
   route {
       cidr_block = "0.0.0.0/0"
-      gateway_id = "${aws_internet_gateway.default.id}"
+      gateway_id = aws_internet_gateway.default.id
   }
-  tags {
+  tags = {
       Name = "terraform_public_subnet_route_table"
   }
 }
 
 resource "aws_route_table_association" "demo_public" {
-  subnet_id = "${aws_subnet.demo_public.id}"
-  route_table_id = "${aws_route_table.demo_public.id}"
+  subnet_id = aws_subnet.demo_public.id
+  route_table_id = aws_route_table.demo_public.id
 }
 
 #
 # Private Subnet
 #
 resource "aws_subnet" "demo_private" {
-  vpc_id = "${aws_vpc.default.id}"
-  cidr_block = "${var.private_subnet_cidr}"
-  availability_zone = "${element(var.availability_zones, 0)}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  cidr_block = var.private_subnet_cidr
+  availability_zone = element(var.availability_zones, 0)
+  tags = {
       Name = "terraform_private_subnet"
   }
 }
 output "private_subnet_id" {
-  value = "${aws_subnet.demo_private.id}"
+  value = aws_subnet.demo_private.id
 }
 
 resource "aws_route_table" "demo_private" {
-  vpc_id = "${aws_vpc.default.id}"
+  vpc_id = aws_vpc.default.id
   route {
       cidr_block = "0.0.0.0/0"
-      instance_id = "${aws_instance.nat.id}"
+      instance_id = aws_instance.nat.id
   }
-  tags {
+  tags = {
       Name = "terraform_private_subnet_route_table"
   }
 }
 
 resource "aws_route_table_association" "demo_private" {
-  subnet_id = "${aws_subnet.demo_private.id}"
-  route_table_id = "${aws_route_table.demo_private.id}"
+  subnet_id = aws_subnet.demo_private.id
+  route_table_id = aws_route_table.demo_private.id
 }

--- a/terraform_demo/site/webapp-sg.tf
+++ b/terraform_demo/site/webapp-sg.tf
@@ -23,13 +23,13 @@ resource "aws_security_group" "webapp_http_inbound_sg" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform_demo_webapp_http_inbound"
   }
 }
 output "webapp_http_inbound_sg_id" {
-  value = "${aws_security_group.webapp_http_inbound_sg.id}"
+  value = aws_security_group.webapp_http_inbound_sg.id
 }
 
 resource "aws_security_group" "webapp_ssh_inbound_sg" {
@@ -39,15 +39,15 @@ resource "aws_security_group" "webapp_ssh_inbound_sg" {
     from_port = 22
     to_port = 22
     protocol = "tcp"
-    cidr_blocks = ["${var.ip_range}"]
+    cidr_blocks = [var.ip_range]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform_demo_webapp_ssh_inbound"
   }
 }
 output "webapp_ssh_inbound_sg_id" {
-  value = "${aws_security_group.webapp_ssh_inbound_sg.id}"
+  value = aws_security_group.webapp_ssh_inbound_sg.id
 }
 
 resource "aws_security_group" "webapp_outbound_sg" {
@@ -59,11 +59,11 @@ resource "aws_security_group" "webapp_outbound_sg" {
     protocol = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-  vpc_id = "${aws_vpc.default.id}"
-  tags {
+  vpc_id = aws_vpc.default.id
+  tags = {
       Name = "terraform_demo_webapp_outbound"
   }
 }
 output "webapp_outbound_sg_id" {
-  value = "${aws_security_group.webapp_outbound_sg.id}"
+  value = aws_security_group.webapp_outbound_sg.id
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Terraform v0.12 introduced breaking changes.
This PR fixes these and makes the Terraform configurations run under the latest version at the moment - v0.12.21.
It also addresses the deprecated warning "Interpolation-only expressions are deprecated".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
