### PR TITLE
Updates with working version of code

### DIFF
--- a/terraform_demo/autoscaling_groups/webapp-asg.tf
+++ b/terraform_demo/autoscaling_groups/webapp-asg.tf
@@ -14,7 +14,7 @@ resource "aws_autoscaling_group" "webapp_asg" {
   name = "demo_webapp_asg-${var.webapp_lc_name}"
   max_size = "${var.asg_max}"
   min_size = "${var.asg_min}"
-  wait_for_elb_capacity = false
+  wait_for_elb_capacity = 1
   force_delete = true
   launch_configuration = "${var.webapp_lc_id}"
   load_balancers = ["${var.webapp_elb_name}"]
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_up_alarm" {
   statistic = "Average"
   threshold = "80"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
       AutoScalingGroupName = "${aws_autoscaling_group.webapp_asg.name}"
   }
   alarm_description = "EC2 CPU Utilization"
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "scale_down_alarm" {
   statistic = "Average"
   threshold = "30"
   insufficient_data_actions = []
-  dimensions {
+  dimensions = {
       AutoScalingGroupName = "${aws_autoscaling_group.webapp_asg.name}"
   }
   alarm_description = "EC2 CPU Utilization"

--- a/terraform_demo/instances/bastion.tf
+++ b/terraform_demo/instances/bastion.tf
@@ -17,7 +17,7 @@ resource "aws_instance" "bastion" {
   subnet_id = "${var.public_subnet_id}"
   associate_public_ip_address = true
   vpc_security_group_ids = ["${var.bastion_ssh_sg_id}"]
-  key_name = "${var.key_name}"
+  key_name = "oregon"
 }
 
 resource "aws_eip" "bastion" {

--- a/terraform_demo/instances/private_subnet_instance.tf
+++ b/terraform_demo/instances/private_subnet_instance.tf
@@ -19,5 +19,5 @@ resource "aws_instance" "private_subnet_instance" {
     "${var.ssh_from_bastion_sg_id}",
     "${var.web_access_from_nat_sg_id}"
     ]
-  key_name = "${var.key_name}"
+  key_name = "oregon"
 }

--- a/terraform_demo/launch_configurations/webapp-lc.tf
+++ b/terraform_demo/launch_configurations/webapp-lc.tf
@@ -18,7 +18,7 @@ resource "aws_launch_configuration" "webapp_lc" {
     "${var.webapp_outbound_sg_id}"
   ]
   user_data = "${file("./launch_configurations/userdata.sh")}"
-  key_name = "${var.key_name}"
+  key_name = "oregon"
   associate_public_ip_address = true
 }
 output "webapp_lc_id" {

--- a/terraform_demo/load_balancers/webapp-elb.tf
+++ b/terraform_demo/load_balancers/webapp-elb.tf
@@ -25,7 +25,7 @@ resource "aws_elb" "webapp_elb" {
     interval = 10
   }
   security_groups = ["${var.webapp_http_inbound_sg_id}"]
-  tags {
+  tags = {
       Name = "terraform_elb"
   }
 }

--- a/terraform_demo/site/bastion-sg.tf
+++ b/terraform_demo/site/bastion-sg.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "bastion_ssh_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform_bastion_ssh"
   }
 }
@@ -45,7 +45,7 @@ resource "aws_security_group" "ssh_from_bastion_sg" {
     ]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform_ssh_from_bastion"
   }
 }

--- a/terraform_demo/site/nat-sg.tf
+++ b/terraform_demo/site/nat-sg.tf
@@ -36,7 +36,7 @@ resource "aws_security_group" "nat" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform"
   }
 }
@@ -72,7 +72,7 @@ resource "aws_security_group" "web_access_from_nat_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform"
   }
 }

--- a/terraform_demo/site/pub_priv_vpc.tf
+++ b/terraform_demo/site/pub_priv_vpc.tf
@@ -11,14 +11,14 @@
 resource "aws_vpc" "default" {
   cidr_block = "${var.vpc_cidr}"
   enable_dns_hostnames = true
-  tags {
+  tags = {
       Name = "terraform_vpc"
   }
 }
 
 resource "aws_internet_gateway" "default" {
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform_igw"
   }
 }
@@ -33,12 +33,12 @@ resource "aws_instance" "nat" {
   ami = "ami-75ae8245" # this is a special ami preconfigured to do NAT
   availability_zone = "${element(var.availability_zones, 0)}"
   instance_type = "t2.small"
-  key_name = "${var.key_name}"
+  key_name = "oregon"
   security_groups = ["${aws_security_group.nat.id}"]
   subnet_id = "${aws_subnet.demo_public.id}"
   associate_public_ip_address = true
   source_dest_check = false
-  tags {
+  tags = {
       Name = "terraform_nat_instance"
   }
 }
@@ -55,7 +55,7 @@ resource "aws_subnet" "demo_public" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "${var.public_subnet_cidr}"
   availability_zone = "${element(var.availability_zones, 0)}"
-  tags {
+  tags = {
       Name = "terraform_public_subnet"
   }
 }
@@ -69,7 +69,7 @@ resource "aws_route_table" "demo_public" {
       cidr_block = "0.0.0.0/0"
       gateway_id = "${aws_internet_gateway.default.id}"
   }
-  tags {
+  tags = {
       Name = "terraform_public_subnet_route_table"
   }
 }
@@ -86,7 +86,7 @@ resource "aws_subnet" "demo_private" {
   vpc_id = "${aws_vpc.default.id}"
   cidr_block = "${var.private_subnet_cidr}"
   availability_zone = "${element(var.availability_zones, 0)}"
-  tags {
+  tags = {
       Name = "terraform_private_subnet"
   }
 }
@@ -100,7 +100,7 @@ resource "aws_route_table" "demo_private" {
       cidr_block = "0.0.0.0/0"
       instance_id = "${aws_instance.nat.id}"
   }
-  tags {
+  tags = {
       Name = "terraform_private_subnet_route_table"
   }
 }

--- a/terraform_demo/site/webapp-sg.tf
+++ b/terraform_demo/site/webapp-sg.tf
@@ -24,7 +24,7 @@ resource "aws_security_group" "webapp_http_inbound_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform_demo_webapp_http_inbound"
   }
 }
@@ -42,7 +42,7 @@ resource "aws_security_group" "webapp_ssh_inbound_sg" {
     cidr_blocks = ["${var.ip_range}"]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform_demo_webapp_ssh_inbound"
   }
 }
@@ -60,7 +60,7 @@ resource "aws_security_group" "webapp_outbound_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
   vpc_id = "${aws_vpc.default.id}"
-  tags {
+  tags = {
       Name = "terraform_demo_webapp_outbound"
   }
 }


### PR DESCRIPTION
*Issue , if available:*

*Description of changes:*

*Issue #16 
**terraform get** 

README.md steps mentions the use of “terraform get” which is no more in use

-------------------------------------------------------------------------------
**- Tags argument usage**

Usage of tags argument is incorrect, as the latest versions of terraform use an equals sign to assign values.

Error: Unsupported block type
│ 
│   on site/pub_priv_vpc.tf line 14, in resource "aws_vpc" "default":
│   14:   tags {
│ 
│ Blocks of type "tags" are not expected here. Did you mean to define argument "tags"? If so, use the equals sign to assign it a value.

The same errors occurs in :
site/webapp-sg.tf
site/nat-sg.tf
site/bastion-sg.tf
load_balancers/webapp-elb.tf

-------------------------------------------------------------------------------
**wait_for_elb_capacity usage is incorrect**

Usage of wait_for_elb_capacity property in aws_autoscaling_group resource is incorrect. 

Error: Incorrect attribute value type
│ 
│   on autoscaling_groups/webapp-asg.tf line 17, in resource "aws_autoscaling_group" "webapp_asg":
│   17:   wait_for_elb_capacity = false
│ 
│ Inappropriate value for attribute "wait_for_elb_capacity": number required.

-------------------------------------------------------------------------------
**Variables can be referenced without double quotes** 

All variables are referenced using ${} which is no longer needed. 

-------------------------------------------------------------------------------
**Terraform destroy issue resolved**

In the [README](https://github.com/aws-samples/apn-blog/tree/tf_blog_v1.0/terraform_demo#destroying) step of destroying resources via Terraform, it has been mentioned due to this [GitHub Issue](https://github.com/hashicorp/terraform/issues/2493), create_before_destroy lifecycle policy has to be manually changed to false in autoscaling_groups/webapp-asg.tf and launch_configurations/webapp-lc.tf files. Now this GitHub Issue seems to be closed, so recommended to test if the resources are destroyed via Terraform without this manual change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
